### PR TITLE
fix composer name

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "marcocianci/WordCounter",
+    "name": "marcocianci/word-counter",
     "description": "Recursive Word Counter",
     "keywords": ["recursive","word","counter"],
     "homepage": "http://www.github.com/marcocianci/word-counter",


### PR DESCRIPTION
Deprecation warning: Your package name marcocianci/WordCounter is invalid, it should not contain uppercase characters. We suggest using marcocianci/word-counter instead. Make sure you fix this as Composer 2.0 will error.